### PR TITLE
Add intent performer pattern

### DIFF
--- a/Nyanble/ContentView.swift
+++ b/Nyanble/ContentView.swift
@@ -11,6 +11,8 @@ import SwiftData
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var items: [Item]
+    @State private var showNearbyPlaces = false
+    @State private var nearbyPlaces: [RecommendedPlace] = []
 
     var body: some View {
         NavigationSplitView {
@@ -38,9 +40,22 @@ struct ContentView: View {
                         Label("Add Item", systemImage: "plus")
                     }
                 }
+                ToolbarItem {
+                    Button("Nearby Places") {
+                        do {
+                            nearbyPlaces = try NearbyRecommendationsIntent.perform(())
+                            showNearbyPlaces = true
+                        } catch {
+                            print("Failed to get recommendations: \(error)")
+                        }
+                    }
+                }
             }
         } detail: {
             Text("Select an item")
+        }
+        .sheet(isPresented: $showNearbyPlaces) {
+            RecommendedPlacesView(places: nearbyPlaces)
         }
     }
 

--- a/Nyanble/NearbyRecommendationsIntent.swift
+++ b/Nyanble/NearbyRecommendationsIntent.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftUI
+import AppIntents
+
+protocol IntentPerformer {
+    associatedtype Input
+    associatedtype Output
+    static func perform(_ input: Input) throws -> Output
+}
+
+struct RecommendedPlace: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let detail: String
+}
+
+struct RecommendedPlacesView: View {
+    let places: [RecommendedPlace]
+
+    var body: some View {
+        List(places) { place in
+            VStack(alignment: .leading) {
+                Text(place.name).bold()
+                Text(place.detail).font(.caption).foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+struct NearbyRecommendationsIntent: AppIntent, IntentPerformer {
+    typealias Input = Void
+    typealias Output = [RecommendedPlace]
+
+    static let title: LocalizedStringResource = "Show Nearby Recommendations"
+    static let supportedModes: IntentModes = .foreground
+
+    static func perform(_ input: Input) throws -> Output {
+        [
+            RecommendedPlace(name: "Nyan Park", detail: "A nice park to relax."),
+            RecommendedPlace(name: "Cat Cafe", detail: "Enjoy drinks with cats."),
+            RecommendedPlace(name: "River Walk", detail: "Beautiful riverside path.")
+        ]
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let places = try Self.perform(())
+
+        return .result(
+            dialog: "Here are some places near you.",
+            view: RecommendedPlacesView(places: places)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- create `IntentPerformer` protocol for AppIntent execution
- refactor `NearbyRecommendationsIntent` to conform
- show recommendations via a sheet instead of `openAppIntent`

## Testing
- ❌ `xcodebuild -list -project Nyanble.xcodeproj` (failed: command not found)
- ❌ `swift test` (failed: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_684d0e97d6048320bbe67b203696e462