### PR TITLE
Use FoundationModels for recommendations

### DIFF
--- a/Nyanble/ContentView.swift
+++ b/Nyanble/ContentView.swift
@@ -42,11 +42,13 @@ struct ContentView: View {
                 }
                 ToolbarItem {
                     Button("Nearby Places") {
-                        do {
-                            nearbyPlaces = try NearbyRecommendationsIntent.perform(())
-                            showNearbyPlaces = true
-                        } catch {
-                            print("Failed to get recommendations: \(error)")
+                        Task {
+                            do {
+                                nearbyPlaces = try await NearbyRecommendationsIntent.perform(())
+                                showNearbyPlaces = true
+                            } catch {
+                                print("Failed to get recommendations: \(error)")
+                            }
                         }
                     }
                 }

--- a/Nyanble/NearbyRecommendationsIntent.swift
+++ b/Nyanble/NearbyRecommendationsIntent.swift
@@ -1,17 +1,30 @@
 import Foundation
 import SwiftUI
 import AppIntents
+import FoundationModels
 
 protocol IntentPerformer {
     associatedtype Input
     associatedtype Output
-    static func perform(_ input: Input) throws -> Output
+    static func perform(_ input: Input) async throws -> Output
 }
 
 struct RecommendedPlace: Identifiable, Hashable {
     let id = UUID()
     let name: String
     let detail: String
+}
+
+@Generable
+struct AIRecommendedPlace {
+    var name: String
+    var detail: String
+}
+
+@Generable
+struct AIRecommendations {
+    @Guide(description: "A list of recommended nearby places", .count(3))
+    var places: [AIRecommendedPlace]
 }
 
 struct RecommendedPlacesView: View {
@@ -34,17 +47,25 @@ struct NearbyRecommendationsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = "Show Nearby Recommendations"
     static let supportedModes: IntentModes = .foreground
 
-    static func perform(_ input: Input) throws -> Output {
-        [
-            RecommendedPlace(name: "Nyan Park", detail: "A nice park to relax."),
-            RecommendedPlace(name: "Cat Cafe", detail: "Enjoy drinks with cats."),
-            RecommendedPlace(name: "River Walk", detail: "Beautiful riverside path.")
-        ]
+    static func perform(_ input: Input) async throws -> Output {
+        let session = LanguageModelSession()
+        let prompt = """
+        Suggest three interesting places for today's outing. For each, provide a short name and description.
+        """
+
+        let response = try await session.respond(
+            to: prompt,
+            generating: AIRecommendations.self
+        )
+
+        return response.content.places.map {
+            RecommendedPlace(name: $0.name, detail: $0.detail)
+        }
     }
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        let places = try Self.perform(())
+        let places = try await Self.perform(())
 
         return .result(
             dialog: "Here are some places near you.",


### PR DESCRIPTION
## Summary
- fetch nearby recommendations using `LanguageModelSession`
- trigger the intent from the main view with async `Task`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684d12f030e88320a056205310bbddb5