### PR TITLE
Add AppEntity compliance for RecommendedPlace

### DIFF
--- a/Nyanble/Features/Recommendations/Model/RecommendedPlace.swift
+++ b/Nyanble/Features/Recommendations/Model/RecommendedPlace.swift
@@ -1,9 +1,29 @@
 import Foundation
+import AppIntents
 
-struct RecommendedPlace: Identifiable, Hashable {
-    let id = UUID()
+struct RecommendedPlace: Identifiable, Hashable, AppEntity {
+    let id: UUID
     let name: String
     let detail: String
     let latitude: Double
     let longitude: Double
+
+    init(id: UUID = UUID(), name: String, detail: String, latitude: Double, longitude: Double) {
+        self.id = id
+        self.name = name
+        self.detail = detail
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Recommended Place")
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: name,
+            subtitle: detail
+        )
+    }
+
+    static let defaultQuery = RecommendedPlaceQuery()
 }

--- a/Nyanble/Features/Recommendations/Model/RecommendedPlaceQuery.swift
+++ b/Nyanble/Features/Recommendations/Model/RecommendedPlaceQuery.swift
@@ -1,0 +1,7 @@
+import AppIntents
+
+struct RecommendedPlaceQuery: EntityQuery {
+    func entities(for identifiers: [RecommendedPlace.ID]) async throws -> [RecommendedPlace] {
+        []
+    }
+}


### PR DESCRIPTION
## Summary
- make `RecommendedPlace` adopt `AppEntity`
- supply `RecommendedPlaceQuery` for the entity's default query

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d320930648320bb662d4431cab4cf