### PR TITLE
Improve recommendations with MapKit coordinates

### DIFF
--- a/Nyanble/Features/Recommendations/Model/AIRecommendedPlace.swift
+++ b/Nyanble/Features/Recommendations/Model/AIRecommendedPlace.swift
@@ -8,10 +8,4 @@ struct AIRecommendedPlace {
 
     @Guide(description: "Description of the place")
     var detail: String
-
-    @Guide(description: "Latitude of the place")
-    var latitude: Double
-
-    @Guide(description: "Longitude of the place")
-    var longitude: Double
 }

--- a/Nyanble/Shared/Services/PlaceResolver.swift
+++ b/Nyanble/Shared/Services/PlaceResolver.swift
@@ -1,0 +1,40 @@
+import CoreLocation
+import MapKit
+
+struct PlaceResolver {
+    func resolvePlaces(_ llmPlaces: [AIRecommendedPlace], near center: CLLocation) async -> [RecommendedPlace] {
+        await withTaskGroup(of: RecommendedPlace?.self) { group in
+            for place in llmPlaces {
+                group.addTask {
+                    let request = MKLocalSearch.Request()
+                    request.naturalLanguageQuery = place.name
+                    request.region = MKCoordinateRegion(center: center.coordinate,
+                                                         latitudinalMeters: 2000,
+                                                         longitudinalMeters: 2000)
+                    guard let mapItem = try? await MKLocalSearch(request: request).start().mapItems.first,
+                          let location = mapItem.placemark.location,
+                          location.distance(from: center) <= 100 else { return nil }
+
+                    let directionsRequest = MKDirections.Request()
+                    directionsRequest.source = .init(placemark: .init(coordinate: center.coordinate))
+                    directionsRequest.destination = mapItem
+                    directionsRequest.transportType = .walking
+                    _ = try? await MKDirections(request: directionsRequest).calculate().routes.first
+
+                    return RecommendedPlace(name: place.name,
+                                             detail: place.detail,
+                                             latitude: location.coordinate.latitude,
+                                             longitude: location.coordinate.longitude)
+                }
+            }
+
+            var results: [RecommendedPlace] = []
+            for await place in group {
+                if let place {
+                    results.append(place)
+                }
+            }
+            return results
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adjust `AIRecommendedPlace` to only hold name and detail from the LLM
- resolve coordinates with a new `PlaceResolver` using `MKLocalSearch`
- update `RecommendationsIntent` prompt and integrate `PlaceResolver`

## Testing
- `swift --version`
- `xcodebuild -list -project Nyanble.xcodeproj` *(fails: command not found)*
- `swiftlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851201a27e88320afe9159039e83618